### PR TITLE
Add retries to on initial server setup to fix connection timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ vendor
 Gemfile.lock
 bin/*
 .bundle/*
+.idea
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -132,6 +132,9 @@ service "couchbase-server" do
 end
 
 couchbase_node "self" do
+  retries 5
+  retry_delay 2
+  
   database_path node['couchbase']['server']['database_path']
   index_path node['couchbase']['server']['index_path']
 


### PR DESCRIPTION
Similar to pull request https://github.com/urbandecoder/couchbase/pull/27

localhost:8091 connection timeout errors on VirtualBox and a 2GB machine at Digitalocean.com during server install.

Adding retries sorts this issue for me on both platforms.

This pull request is the same as #27 but I noticed master is newer with merged couchbase_node blocks so it may integrate easier.

    couchbase_node "self" do
      retries 5
      retry_delay 2
      
      database_path node['couchbase']['server']['database_path']
      index_path node['couchbase']['server']['index_path']
    
      username node['couchbase']['server']['username']
      password node['couchbase']['server']['password']
    end
