### PR TITLE
URI Encode the Server Path

### DIFF
--- a/libraries/client.rb
+++ b/libraries/client.rb
@@ -3,7 +3,7 @@ module Couchbase
     private
 
     def uri_from_path(path)
-      URI.parse "http://#{@new_resource.username}:#{@new_resource.password}@localhost:8091#{path}"
+      URI.parse(URI.encode("http://#{@new_resource.username}:#{@new_resource.password}@localhost:8091#{path}"))
     end
 
     def post(path, params)


### PR DESCRIPTION
Pretty self explanatory.

If the password, or I suppose even the username, includes a character like `#` you run into some awkward situations if you aren't encoding the URI.